### PR TITLE
fix(openai): retry without temperature for reasoning models

### DIFF
--- a/src/econsimulacra/llm_services/clients/openai_client.py
+++ b/src/econsimulacra/llm_services/clients/openai_client.py
@@ -76,31 +76,34 @@ class OpenAIClient(LLMClient):
             dict[str, Any]: The parsed JSON response from the OpenAI API.
         """
         schema: dict[str, Any] = copy.deepcopy(self.json_schema)
+        use_temperature: bool = True
         for _ in range(self.max_retries):
             try:
+                # reasoning models (e.g. o-series, gpt-5.x) only accept the
+                # default temperature, so drop it after a temperature rejection
+                request: dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "agent_action",
+                            "strict": True,
+                            "schema": schema,
+                        },
+                    },
+                }
+                if use_temperature:
+                    request["temperature"] = self.temperature
                 async with self._sem:
                     response: ChatCompletion = (
-                        await self.client.chat.completions.create(
-                            model=self.model_name,
-                            temperature=self.temperature,
-                            messages=[
-                                {
-                                    "role": "user",
-                                    "content": prompt,
-                                }
-                            ],
-                            response_format={
-                                "type": "json_schema",
-                                "json_schema": {
-                                    "name": "agent_action",
-                                    "strict": True,
-                                    "schema": schema,
-                                },
-                            },
-                        )
+                        await self.client.chat.completions.create(**request)
                     )
                 break
             except BadRequestError as e:
+                if use_temperature:
+                    use_temperature = False
+                    continue
                 print(f"[BadRequestError] {e}")
                 return {}
             except RateLimitError as e:


### PR DESCRIPTION
### Problem
`OpenAIClient.generate_response` sends the configured `temperature` on every request. OpenAI reasoning models (o-series, gpt-5.x) reject any non-default `temperature` with a `BadRequestError`. The handler catches `BadRequestError` and returns `{}`, so with a non-default `temperature` in the config these models silently produce empty actions (the agent does nothing) for the entire run, with only a console print.

### Fix
On a `BadRequestError`, retry once without the `temperature` field (falling back to the model default) before giving up. Default-temperature configs and non-reasoning models are unaffected.

### Notes
- Minimal change, no new dependencies.
- Verified against a gpt-5.x model: a request carrying a custom `temperature` returns 400; the identical request without `temperature` succeeds.