### PR TITLE
feat(time): add revealTimeOfDay option to hide the wall-clock from agents

### DIFF
--- a/src/econsimulacra/envs/base.py
+++ b/src/econsimulacra/envs/base.py
@@ -244,11 +244,12 @@ class Environment(Generic[ObsT]):
 
         Note:
             If a TimeTranslator service provider is available, use it to convert the internal time step
-            to a datetime string; otherwise, return the internal time step as an integer.
+            to the agent-facing time (a datetime string, or the step index when
+            ``revealTimeOfDay`` is disabled); otherwise, return the internal time step as an integer.
         """
         time_translator: Optional[TimeTranslator] = self.get_time_translator()
         if time_translator is not None:
-            return time_translator.step_to_datetime(self._time)
+            return time_translator.step_to_display_time(self._time)
         return self._time
 
     def get_time_step(self) -> int:

--- a/src/econsimulacra/envs/time_translator.py
+++ b/src/econsimulacra/envs/time_translator.py
@@ -49,6 +49,10 @@ class TimeTranslator:
         self.prng: random.Random = prng if prng is not None else random.Random()
         self.registered_classes: list[Type] = registered_classes
 
+        # when disabled, agents are shown the step index instead of a wall-clock
+        # time, so they cannot anchor behaviour to the time of day
+        self.reveal_time_of_day: bool = config.get("revealTimeOfDay", True)
+
         self.active_time_ranges: list[tuple[time, time]] = (
             self._parse_active_time_ranges(config.get("activeTimeRanges", []))
         )
@@ -198,6 +202,18 @@ class TimeTranslator:
             return self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")
 
         return self.step_datetimes[step].strftime("%Y-%m-%d %H:%M:%S")
+
+    def step_to_display_time(self, step: int) -> int | str:
+        """Convert a step to the time shown to agents.
+
+        Returns the wall-clock datetime when ``revealTimeOfDay`` is set (the
+        default), otherwise the integer step index. Hiding the time of day lets
+        one test whether temporal patterns arise from the agents' internal
+        dynamics rather than from reading the clock.
+        """
+        if self.reveal_time_of_day:
+            return self.step_to_datetime(step)
+        return step
 
     def get_timedelta(self) -> str:
         """Get the mimimum time delta for each simulation step.

--- a/tests/test_time_translator.py
+++ b/tests/test_time_translator.py
@@ -63,3 +63,17 @@ class TestTimeTranslator:
     def test_get_timedelta(self) -> None:
         time_translator = TimeTranslator(config=self.config)
         assert time_translator.get_timedelta() == "0:01:00"
+
+    def test_step_to_display_time(self) -> None:
+        revealed = TimeTranslator(config=self.config)
+        assert revealed.reveal_time_of_day is True
+        for step in range(self.config["numSteps"]):
+            assert revealed.step_to_display_time(step) == revealed.step_to_datetime(
+                step
+            )
+
+        hidden = TimeTranslator(config={**self.config, "revealTimeOfDay": False})
+        assert hidden.reveal_time_of_day is False
+        for step in range(self.config["numSteps"]):
+            assert hidden.step_to_display_time(step) == step
+        assert hidden.step_to_display_time(-1) == -1


### PR DESCRIPTION
### Summary
Adds a `revealTimeOfDay` flag to `TimeTranslator` (default `true`, fully backward-compatible). When set to `false`, agents are shown the **integer step index** instead of the wall-clock datetime, so they cannot anchor behavior to the time of day.

### Motivation
Agents currently see the absolute time (e.g. `2025-03-03 00:00:00`) in their observation and memory. When studying whether human-like temporal structure (circadian rhythm, bursty activity) *emerges from agents' internal dynamics* rather than from simply reading the clock, the visible time-of-day is a confound. This flag enables a clock-hidden condition to compare against.

### Behavior
- `revealTimeOfDay: true` (default) — unchanged; `get_time()` returns the wall-clock datetime.
- `revealTimeOfDay: false` — `get_time()` returns the integer step index.
- Logged records use the same value; `log_analyses` (e.g. `TemporalDynamicsAnalyzer`) key off the integer `time_step`, so inter-event / burstiness / period metrics are unaffected (clock-hour histograms naturally aren't meaningful when the clock is hidden).

### Changes
- `TimeTranslator`: `revealTimeOfDay` config + `step_to_display_time(step)`.
- `Environment.get_time()` routes through `step_to_display_time` (one line).
- Test covering both modes; existing `test_time_translator.py` still passes.

### Usage
```jsonc
"timeTranslator": {
  "type": "TimeTranslator",
  "numSteps": 168,
  "startDatetime": "2025-03-01 00:00:00",
  "endDatetime": "2025-03-08 00:00:00",
  "revealTimeOfDay": false
}
```